### PR TITLE
Load intended configuration explicitly, return default correctly.

### DIFF
--- a/tests/ApplySecureHeadersTest.php
+++ b/tests/ApplySecureHeadersTest.php
@@ -18,10 +18,17 @@ class ApplySecureHeadersTest extends TestCase
      */
     public function testMiddlewareAddsAppropriateHeaders()
     {
+        // configuration
+        $map = [
+            ['secure-headers.csp', [], ['csp' => []]],
+            ['secure-headers.hsts.enabled', false, true],
+            ['secure-headers.safeMode', false, true],
+        ];
+
         $config = $this->createMock(Repository::class);
-        $config->method('get')->willReturn(['csp' => []]);
-        $config->method('get')->willReturn(true); // hsts
-        $config->method('get')->willReturn(true); // safeMode
+        $config->method('get')->will($this->returnValueMap($map));
+        // return default (second arg) if not in configuration
+        $config->method('get')->will($this->returnArgument(1));
 
         $request = new Request();
 


### PR DESCRIPTION
This decouples the call order from the test succeeding, and affords
the assumption that retrieving items from the configuration
is non mutating, and will give the same results.

This also separates implementation details of the code being tested
from the tests themselves.