### PR TITLE
Allow errorReporting to be configured on/off

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -1,6 +1,9 @@
 <?php
 
 return [
+    // Toggles error reporting, see https://github.com/aidantwoods/SecureHeaders/wiki/errorReporting
+    'errorReporting' => true,
+
     // Safe mode
     'safeMode' => false,
 

--- a/src/ApplySecureHeaders.php
+++ b/src/ApplySecureHeaders.php
@@ -46,6 +46,8 @@ class ApplySecureHeaders
     {
         $response = $next($request);
 
+        $this->headers->errorReporting($this->config->get('secure-headers.errorReporting', true));
+
         $this->setHsts();
         $this->setCsp();
         $this->setMode();


### PR DESCRIPTION
Needed a way to cut out the warnings while in a transitional mode on a project that cant yet follow best practices.