### PR TITLE
Updated dependencies for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,9 @@
     "require": {
         "php": "7.x",
         "aidantwoods/secureheaders": "^2.0",
-        "illuminate/http": "^5.4|^6",
-        "illuminate/support": "^5.4|^6"
+        "illuminate/contracts": ">=5.4",
+        "illuminate/http": ">=5.4",
+        "illuminate/support": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",


### PR DESCRIPTION
This PR is to fix the issue https://github.com/mikefrancis/laravel-secureheaders/issues/35 

One question though, I ran the unit test and it shows a bunch of warnings and notices:
![image](https://user-images.githubusercontent.com/21353103/75872146-a52bf880-5e48-11ea-84fb-1d4bb4b22a8d.png)
I also see this whenever I serve my Laravel app. Is this intended?
 